### PR TITLE
Fix Error in subscriptions model

### DIFF
--- a/models/subscriptions.js
+++ b/models/subscriptions.js
@@ -36,11 +36,6 @@ const subscriptionSchema = new mongoose.Schema({
     default: false
   },
   appointments: {
-    type: [{
-      _id: {
-        type: mongoose.Schema.Types.ObjectId,
-        default: mongoose.Types.ObjectId()
-      },
       date: {
         type: Date,
         requried: [true, `please add date to appointment`]


### PR DESCRIPTION
- remove function that was create static mongoose id to appointment
- mongoose now generetes appointment ids by default